### PR TITLE
商品売切れ表示

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the card controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/modules/_show_item.scss
+++ b/app/assets/stylesheets/modules/_show_item.scss
@@ -195,6 +195,18 @@
               border-radius: 100px;
               margin: 20px;
             }
+            .disabled-button {
+              text-align: center;
+              text-decoration: none;
+              line-height: 48px;
+              background-color: red;
+              border: 1px solid #3CCACE;
+              color: #fff;
+              width: 60%;
+              font-size: 18px;
+              border-radius: 100px;
+              margin: 20px;
+            }
           }
         }
         .commentBox{

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the purchase controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -34,6 +34,7 @@ class PurchaseController < ApplicationController
 
   def done
     @item = Item.find(params[:id])
+    @item.update( buyer_id: current_user.id)
   end
 
 end

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,2 +1,5 @@
 %li.images
   = image_tag item.images.first.image.url, class:"image1"
+  -if @item.buyer_id.present?
+    .items-box_photo__sold
+      .items-box_photo__sold__inner SOLD

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -86,7 +86,11 @@
                 商品の編集
               = link_to item_path(@item.id), method: :delete, class: "destroy_btn" do
                 商品の削除
-          -elsif user_signed_in? && current_user.id != @item.id
+          -elsif @item.buyer_id.present?
+            .purchase
+              = link_to root_path, class: "disabled-button" do
+                残念！売切れました
+          -else
             .purchase
               = link_to purchase_path, class:"purchase_btn" do
                 商品の購入


### PR DESCRIPTION
# What
売切れ表示機能を実装する。
・商品購入ボタンを押すとその商品のbuyer idが現在のユーザーに紐づく＝売り切れ
・売切れになると商品一覧、商品詳細画面に売り切れ表示。
・商品詳細画面で「購入する」ボタンが表示されない

# Why
この機能がないと売れた商品が再び買うことができてしまうため。