### PR TITLE
クレジットカード登録時バグ修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-//= require turbolinks
+// = require turbolinks
 //= require rails-ujs
 //= require jquery
 //= require_tree .

--- a/app/assets/stylesheets/modules/_mypages.scss
+++ b/app/assets/stylesheets/modules/_mypages.scss
@@ -5,7 +5,7 @@
   display: flex;
 
   .contents{
-    @include -height-width(calc(100vh - 100px), calc(100vw - 700px));
+    @include -height-width(600px, calc(100vw - 700px));
     background-color: white;
     margin:50px 0px 0px 50px;
   }

--- a/app/assets/stylesheets/modules/_sidelist.scss
+++ b/app/assets/stylesheets/modules/_sidelist.scss
@@ -1,5 +1,5 @@
 .sidelist{
-  @include -height-width(650px, 250px);
+  @include -height-width(600px, 250px);
   background-color: white;
   margin:50px 0px 0px 100px;
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,6 @@ class ItemsController < ApplicationController
     @items = Item.includes(:images)
     @user = User.find_by(id: @item.user_id)
     @category = Category.find(params[:id])
-
     @categories = Category.find(params[:id])
   end
 

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,6 +1,6 @@
+= render "toppages/header"
 .payment-wrapper
   = render 'mypages/side_bar'
-
   .contents-head
     .contents-title
       %h2 クレジットカード情報入力

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,9 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    - if content_for?(:body_attributes)
+      = yield(:body_attributes)
     = render 'layouts/notifications'
     = yield

--- a/app/views/mypages/_side_bar.html.haml
+++ b/app/views/mypages/_side_bar.html.haml
@@ -21,7 +21,7 @@
 
     %tr
       %td.list.payment
-        = link_to "　支払い方法", new_card_path, class:"tabel-btn"
+        = link_to "　支払い方法", new_card_path, class:"tabel-btn", "data-turbolinks": false
 
     %tr
       %td.list.logout

--- a/app/views/toppages/index.html.haml
+++ b/app/views/toppages/index.html.haml
@@ -108,7 +108,7 @@
                 .details
                   %ul
                     %li
-                      = item.price
+                      = item.price.to_s(:delimited)
                       円
                     %li
                       %i.fa.fa-star.likeIcon 0
@@ -135,7 +135,7 @@
                 .details
                   %ul
                     %li
-                      = item.price
+                      = item.price.to_s(:delimited)
                       円
                     %li
                       %i.fa.fa-star.likeIcon 0


### PR DESCRIPTION
# what
リロードしないとクレジットカード情報が登録できない問題。

# why
リロードしないと登録できないのは手間なので。

登録画面遷移時のみturbolinksを切って対応しました。