### PR TITLE
クレジットカード登録バグフィックス

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -18,7 +18,7 @@
                   = image_tag image.image.url, class: "image2"
           .itemBox__price
             %span1
-              = (@item.price / 0.9).floor
+              = (@item.price / 0.9).floor.to_s(:delimited)
               円
             .priceDetail
               %span
@@ -91,7 +91,7 @@
               = link_to "残念！売切れました", root_path, class: "disabled-button"                
           -else
             .purchase
-              = link_to "商品の購入", purchase_path, class:"purchase_btn"             
+              = link_to "商品の購入", purchase_path, class:"purchase_btn","data-turbolinks": false             
         .commentBox
           %ul.commentContents
           = form_with url:"#", local: true, class: "new_comment" do |f|

--- a/app/views/toppages/index.html.haml
+++ b/app/views/toppages/index.html.haml
@@ -108,7 +108,7 @@
                 .details
                   %ul
                     %li
-                      = (item.price / 0.9).floor
+                      = (item.price / 0.9).floor.to_s(:delimited)
                       円
                     %li
                       %i.fa.fa-star.likeIcon 0
@@ -135,7 +135,7 @@
                 .details
                   %ul
                     %li
-                      = (item.price / 0.9).floor
+                      = (item.price / 0.9).floor.to_s(:delimited)
                       円
                     %li
                       %i.fa.fa-star.likeIcon 0


### PR DESCRIPTION
# what
ユーザー登録後に初めて商品を購入する際に、商品購入ボタンからクレジットカード登録画面に遷移するときに限り
turbo_linksが動作していたため、items/showの94行目を修正した。
また、トップページのアーカイブと新規投稿商品欄にて、商品金額のカンマが外れていたため修正した。

# why
修正したかったから