### PR TITLE
編集ページのカテゴリー部分の修正

### DIFF
--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -40,20 +40,19 @@
           %span 必須
         .CategoryBox
           .CategoryBoxChoose
-          - if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
-            .append__category
-              .category
-                =f.collection_select :category_id, @category_children_array, :id, :name, {selected:@child_array}, {class:"serect_field"}
-              .category__grandchild#children_wrapper
-                =f.collection_select :category_id, @category_grandchildren_array, :id, :name, {selected:@grandchild_array}, {id:"child__category",class:"serect_field"}
-          - else
-            .append__category
-              .category
-                =f.collection_select :category_id, @category_parent_array, :id, :name, {selected:@parent_array}, {class:"serect_field"}
-              .category__child#children_wrapper
-                =f.collection_select :category_id, @category_children_array, :id, :name, {selected:@child_array}, {id:"child__category", class:"serect_field"}
-              .category__grandchild#grandchildren_wrapper
-                =f.collection_select :category_id, @category_grandchildren_array, :id, :name, {selected:@grandchild_array}, {class:"serect_field"}
+            - if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
+              .append__category
+                .category
+                  =f.collection_select :category_id, @category_children_array, :id, :name, {selected:@child_array}, {class:"serect_field",id:'parent_category'}
+                  =f.collection_select :category_id, @category_grandchildren_array, :id, :name, {selected:@grandchild_array}, {id:"child__category",class:"serect_field"}
+            - else
+              .append__category
+                .category
+                  =f.collection_select :category_id, @category_parent_array, :id, :name,{selected:@parent_array}, {class:"serect_field",id:'parent_category'}   
+                .category__child#children_wrapper
+                  =f.collection_select :category_id, @category_children_array, :id, :name, {selected:@child_array}, {id:"child__category", class:"serect_field"}
+                .category__grandchild#grandchildren_wrapper
+                  =f.collection_select :category_id, @category_grandchildren_array, :id, :name, {selected:@grandchild_array}, {class:"serect_field"}
         .FormLabel
           %label ブランド
           %span.other-span 任意


### PR DESCRIPTION
#what
編集ページの親カテゴリーに伴う子、孫カテゴリー変更の実装
＃why
商品編集時にカテゴリー内容の変更を可能にするため
