### PR TITLE
商品購入バグフィックス

### DIFF
--- a/app/assets/stylesheets/modules/_transactions.scss
+++ b/app/assets/stylesheets/modules/_transactions.scss
@@ -2,26 +2,29 @@
   //フォントの指定
   font-family: "Arial","游ゴシック体","YuGothic","メイリオ","Meiryo","sans-serif";  
 
-  @include -height-width(100vh, 100vw);
+  @include -height-width(700px, 100vw);
   background-color: lightgray;
+  margin-top:20px;
   
-  .header{
+  .purchase-header{
     @include -height-width(100px, 100vw);
-    @include vertical-and-horizontal-center;
+    align-items: center;
+    // @include vertical-and-horizontal-center;
 
     .furima-logo{
-      @include -height-width(75%, 15%);
+      @include -height-width(60%, 20%);
+      
       object-fit: cover;
-      margin-top: 10px;
+      // margin-top: 10px;
     }
   }
 
   .main{
-    @include -height-width(860px, 100vw);
+    @include -height-width(700px, 100vw);
     display: flex;
     justify-content: center;
     &__purchase-details{
-      @include -height-width(750px, 700px);
+      @include -height-width(650px, 700px);
       background-color:white;
       display: flex;
       justify-content: center;
@@ -64,6 +67,16 @@
             left:100px;
             text-align: start;
             font-size: 12px;
+            margin-left: 10px;
+            h1 {
+              font-size:18px;
+              font-weight: 900;
+              margin-top:10px;
+            }
+            &__itemname{
+              font-size: 14px;
+              margin-top:10px;
+            }
           }
           //金額
           &__price{
@@ -100,7 +113,7 @@
       }
       //method-of-payment(支払い方法)
       &__method-of-payment{
-        @include -height-width(200px, 340px);
+        @include -height-width(140px, 340px);
         padding-top: 15px;
         padding-left: 5px;
         border-bottom: 1px solid rgb(60,202,206);
@@ -111,16 +124,17 @@
         }
 
         p.card{
-          margin:0 0 10px 0;
+          margin:0 0 5px 0;
+          line-height: 30px;
         }
 
         &__card{
           @include -height-width(90px, 250px);
-          margin-top: 30px;
+          margin-top: 20px;
           .card-icon{
             @include -height-width(30%, 30%);
             object-fit: cover;
-            margin-top: 10px;
+            margin-top: 5px;
           }
         }
       }
@@ -128,15 +142,17 @@
       &__shipping-address{
         @include -height-width(120px, 340px);
         border-bottom: 1px solid rgb(60,202,206);
-        margin-top: 20px;
-        margin-left: 5px;
+        padding-top: 15px;
+        padding-left: 5px;
         h1 {
-          font-weight: 900;
+          font-size: 18px;
+          font-weight: 600;
         }
-        p {
-          font-size: 14px;
-          font-weight: 400;
+        &__wrapper{
+          margin-top:20px;
+          line-height: 20px;
         }
+ 
       }
 
       //buybtn(購入ボタン)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < ActionController::Base
       password == Rails.application.credentials[:basic_auth][:pass]
     end
   end
-  
 
   def production?
     Rails.env.production?

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -6,6 +6,9 @@ class CardController < ApplicationController
     if user_signed_in?
       card = Card.where(user_id: current_user.id)
       redirect_to action: "show" if card.exists?
+    else
+      redirect_to new_login_path
+      flash[:notice] = '購入するにはログイン・新規登録してください'
     end
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,4 +1,5 @@
 class TransactionsController < ApplicationController
   def show
+    @user = User.find(params[:id])
   end
 end

--- a/app/views/mypages/_side_bar.html.haml
+++ b/app/views/mypages/_side_bar.html.haml
@@ -6,7 +6,7 @@
         = link_to "　トップページ", root_path, class:"tabel-btn"
     %tr
       %td.list.mypage
-        = link_to "　マイページ", mypage_path(current_user.id), class:"tabel-btn"
+        = link_to "　マイページ/ユーザー登録情報", mypage_path(current_user.id), class:"tabel-btn"
     %tr
       %td.list.listed-products
         = link_to "　出品した商品", "#", class:"tabel-btn"

--- a/app/views/mypages/show.html.haml
+++ b/app/views/mypages/show.html.haml
@@ -27,9 +27,13 @@
         .mypage-contents__userinfo-wrapper__address
           %h1.info 配送先住所
           = @destination.prefecture + @destination.address + @destination.second_address
+          = @destination.building_name
         .mypage-contents__userinfo-wrapper__phone_number
           %h1.info 連絡先(携帯電話)
           = "0" + @destination.phone_number.to_s[0..1] + "-" + @destination.phone_number.to_s[2..5] + "-" + @destination.phone_number.to_s[6..9]
+        .mypage-contents__userinfo-wrapper__email
+          %h1.info メールアドレス
+          = @user.email
 
 = render "toppages/footer"
 = render "toppages/purchaseBtn"

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,6 +1,5 @@
+= render "/toppages/header"
 .wrapper
-  .header
-    = image_tag "/material/logo/logo.png", class: "furima-logo"
   .main
     .main__purchase-details
       .main__purchase-details__headline-box
@@ -15,7 +14,9 @@
           .main__purchase-details__product__name-box
             .main__purchase-details__product__name-box__name
               //商品の名前
-              = "　商品名　" + "#{@item.item_name}"
+              %h1 商品名
+              .main__purchase-details__product__name-box__name__itemname
+                = @item.item_name
             .main__purchase-details__product__name-box__price
               = "¥"+"#{@item.price.to_s(:delimited)}"+"(税込)"
 
@@ -32,14 +33,18 @@
         .main__purchase-details__shipping-address
           %h1 配送先住所
           //3桁目と４桁目にハイフンをいれる
-          = "〒" + @destination.zip_code.to_s.insert(3, '-')
-          %br
-          = @destination.prefecture
-          = @destination.address
-          = @destination.second_address
+          .main__purchase-details__shipping-address__wrapper
+            = "〒" + @destination.zip_code.to_s.insert(3, '-')
+            %br
+            = @destination.prefecture
+            = @destination.address
+            = @destination.second_address
+            %br
+            = @destination.building_name
             
 
         .main__purchase-details__buybtn-field
           .main__purchase-details__buybtn-field__buybtn
             = form_tag(action: :pay, method: :post) do
               %button.text-decoration 購入する
+= render "/toppages/footer"


### PR DESCRIPTION
# what
未ログインユーザーが商品詳細画面で購入ボタンを押下した際にエラー画面が表示されていた問題を解消。
新規登録画面にridirect_toで遷移しフラッシュメッセージで「購入するにはログイン・新規登録してください」
を画面上部に表示させた。
card_controllerのnewアクションにelse文を追加。

他
・マイページに登録メールアドレスを表示
・購入確認画面にて登録住所のビル・マンション名を表示
など軽微な修正

# why
致命的なバグだったため。