### PR TITLE
削除確認画面のバグフィックス

### DIFF
--- a/app/views/items/delete.html.haml
+++ b/app/views/items/delete.html.haml
@@ -2,7 +2,9 @@
 .delete-done
   .delete-done__title
     商品を削除しました
-    <meta http-equiv="Refresh" content="5; url=/toppages">
+    -# <meta http-equiv="Refresh" content="5; url=/toppages">
+    //metaタグはiOSでは動作しないため、javaScriptに変更
+    %body{:onload => "setTimeout(\"location.href='/toppages'\",5000)"}
     %p 5秒後にトップページへ移動します
     = link_to 'トップページへ戻る', root_path, class: 'link'
 = render "toppages/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
 
-  # get 'purchase/index'
-  # get 'purchase/done'
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }


### PR DESCRIPTION
# what
削除確認画面の画面自動遷移をmetaタグからjavaScriptに変更。

# why
iOS環境だとmetaタグが動作しない事があるらしいため。